### PR TITLE
Fix an issue regarding the CashCreate method docs

### DIFF
--- a/EpaycoSdk/README.md
+++ b/EpaycoSdk/README.md
@@ -239,7 +239,6 @@ CashModel response = epayco.CashCreate(
     "name",
     "last_name",
     "email",
-    "country",
     "cell_phone",
     "url_response",
     "url_confirmation",);

--- a/EpaycoSdk/README.md
+++ b/EpaycoSdk/README.md
@@ -240,8 +240,10 @@ CashModel response = epayco.CashCreate(
     "last_name",
     "email",
     "cell_phone",
+    "end_date",
     "url_response",
-    "url_confirmation",);
+    "url_confirmation",
+    "method_confirmation");
 ```
 ### Get Cash Transaction
 Ejemplo de la petición:


### PR DESCRIPTION
En la documentación se quita el parametro country de la lista de argumentos que se pueden pasar al método de CashCreate y se agregan unos que faltaban.

https://trello.com/c/JL6cTB0Z/855-no-toma-caracteres-especiales-en-la-descripcion