### PR TITLE
Feature/update bank models

### DIFF
--- a/EpaycoSdk/Epayco.cs
+++ b/EpaycoSdk/Epayco.cs
@@ -445,7 +445,7 @@ namespace EpaycoSdk
             string url_response,
             string url_confirmation,
             string method_confirmation,
-            CashSplitModel split_details = null)
+            SplitModel split_details = null)
         {
             CashModel cash = null;
             string content = "";
@@ -514,7 +514,7 @@ namespace EpaycoSdk
             string extra8 = "N/A",
             string extra9 = "N/A",
             string extra10 = "N/A",
-            CashSplitModel split_details = null)
+            SplitModel split_details = null)
         {
             ENDPOINT = Constants.url_charge;
             PARAMETER = body.getBodyChargeCreate(token_card, customer_id, doc_type, doc_number, name, last_name,

--- a/EpaycoSdk/EpaycoSdk.csproj
+++ b/EpaycoSdk/EpaycoSdk.csproj
@@ -59,9 +59,9 @@
     <Compile Include="Models\Bank\BanksModel.cs" />
     <Compile Include="Models\Bank\PseModel.cs" />
     <Compile Include="Models\Bank\SplitReceivers.cs" />
+    <Compile Include="Models\Bank\SplitModel.cs" />
     <Compile Include="Models\Bank\TransactionModel.cs" />
     <Compile Include="Models\Cash\CashModel.cs" />
-    <Compile Include="Models\Cash\CashSplitModel.cs" />
     <Compile Include="Models\Cash\CashTransactionModel.cs" />
     <Compile Include="Models\Charge\ChargeModel.cs" />
     <Compile Include="Models\Charge\ChargeTransactionModel.cs" />

--- a/EpaycoSdk/Models/Bank/PseModel.cs
+++ b/EpaycoSdk/Models/Bank/PseModel.cs
@@ -25,5 +25,6 @@ namespace EpaycoSdk.Models.Bank
         public string urlbanco { get; set; }
         public string transactionId { get; set; }
         public string ticketId { get; set; }
+        public dynamic errores { get; set; }
     }
 }

--- a/EpaycoSdk/Models/Bank/SplitModel.cs
+++ b/EpaycoSdk/Models/Bank/SplitModel.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
-using EpaycoSdk.Models.Bank;
 
-namespace EpaycoSdk.Models.Cash
+namespace EpaycoSdk.Models.Bank
 {
-    public class CashSplitModel
+    public class SplitModel
     {
         public string splitpayment { get; set; }
         public string split_app_id { get; set; }

--- a/EpaycoSdk/README.md
+++ b/EpaycoSdk/README.md
@@ -260,7 +260,7 @@ Previous requirements: https://docs.epayco.co/tools/split-payment
 Ejemplo de la petición:
 
 ```
-CashSplitModel splitData = new CashSplitModel();
+SplitModel splitData = new SplitModel();
 splitData.splitpayment = "true";
 splitData.split_app_id = "P_CUST_ID_CLIENTE APPLICATION";
 splitData.split_merchant_id = "P_CUST_ID_CLIENTE COMMERCE";
@@ -285,7 +285,7 @@ use the following attributes in case you need to do a dispersion with multiple p
 Ejemplo de la petición:
 
 ```
-CashSplitModel splitData = new CashSplitModel();
+SplitModel splitData = new SplitModel();
 splitData.splitpayment = "true";
 splitData.split_app_id = "P_CUST_ID_CLIENTE APPLICATION";
 splitData.split_merchant_id = "P_CUST_ID_CLIENTE COMMERCE";
@@ -357,7 +357,7 @@ Previous requirements: https://docs.epayco.co/tools/split-payment
 Ejemplo de la petición:
 
 ```
-CashSplitModel splitData = new CashSplitModel();
+SplitModel splitData = new SplitModel();
 splitData.splitpayment = "true";
 splitData.split_app_id = "P_CUST_ID_CLIENTE APPLICATION";
 splitData.split_merchant_id = "P_CUST_ID_CLIENTE COMMERCE";
@@ -382,7 +382,7 @@ use the following attributes in case you need to do a dispersion with multiple p
 Ejemplo de la petición:
 
 ```
-CashSplitModel splitData = new CashSplitModel();
+SplitModel splitData = new SplitModel();
 splitData.splitpayment = "true";
 splitData.split_app_id = "P_CUST_ID_CLIENTE APPLICATION";
 splitData.split_merchant_id = "P_CUST_ID_CLIENTE COMMERCE";

--- a/EpaycoSdk/Utils/BodyRequest.cs
+++ b/EpaycoSdk/Utils/BodyRequest.cs
@@ -351,7 +351,7 @@ namespace EpaycoSdk.Utils
                   "\n\"lenguaje\": \""+".net"+"\"\r\n}";
         }
  
-        public string getBodySplitPayments(CashSplitModel split_details)
+        public string getBodySplitPayments(SplitModel split_details)
         {
            List<SplitReceivers> split_receivers = split_details.split_receivers;
            return Newtonsoft.Json.JsonConvert.SerializeObject(split_details);


### PR DESCRIPTION
Se agrega la propiedad errores al modelo PseModel y se mueve y renombra CashSplitModel a SplitModel.

Los cambios se mencionaron por la QA mientras se estuvo probando estas cards: https://trello.com/c/CpLjWhAc/133-implementaci%C3%B3n-de-split-en-sdk-de-net, https://trello.com/c/JL6cTB0Z/855-no-toma-caracteres-especiales-en-la-descripcion